### PR TITLE
Name change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 City of Turku
+Copyright (c) 2021 Codepoint Turku
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# City of Turku's tsx/jsx Eslint config
+# Codepoint's tsx/jsx ESLint config
 
 [![npm Release Version](https://img.shields.io/github/v/release/codepointtku/jsx-eslint?logo=npm&style=for-the-badge&labelColor=333333)](https://www.npmjs.com/package/@codepointtku/jsx-eslint)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/codepointtku/jsx-eslint/npm%20Publish?logo=githubactions&logoColor=cyan&style=for-the-badge&labelColor=333333)](https://github.com/codepointtku/jsx-eslint/actions/workflows/npm-publish.yml)
 
-* **What is this for?:** This Eslint config is meant to be used for City of Turku's web development projects.
+*Codepoint's ESLint config file for making code more consistent and avoiding bugs.*
+
+* **What is this for?:** This ESLint config is meant to be used for Codepoint's web development projects.
 * **Can anyone use it?:** Yes, you can use this config however you like, but keep in mind that these settings might change over time.
 
 [Contact for questions, information and to contribute](mailto:juuso.laakso@turku.fi)
@@ -19,5 +21,16 @@ $ npm install --dev @codepointtku/jsx-eslint
 ```jsonc
 {
   "extends": "@codepointtku/jsx-eslint"
+}
+```
+
+or to `package.json`
+```jsonc
+{
+  "eslintConfig": {
+    "extends": [
+    "@codepointtku/jsx-eslint"
+    ]
+  }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Installation
 **Run** this command in your repository
 ```bash
-$ npm install --dev @codepointtku/jsx-eslint
+$ npm install --dev @codepointtku/eslint-config-jsx-eslint
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Juuso Laakso",
-  "description": "City of Turku's Eslint config file for Front-end web development",
-  "name": "@codepointtku/jsx-eslint",
+  "description": "Codepoint's ESLint config file for modern web development projects",
+  "name": "@codepointtku/eslint-config-jsx-eslint",
   "version": "1.0.1",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Juuso Laakso",
   "description": "Codepoint's ESLint config file for modern web development projects",
   "name": "@codepointtku/eslint-config-jsx-eslint",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "eslint",
     "eslintconfig"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Juuso Laakso",
   "description": "Codepoint's ESLint config file for modern web development projects",
   "name": "@codepointtku/eslint-config-jsx-eslint",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "keywords": [
     "eslint",
     "eslintconfig"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Juuso Laakso",
   "description": "Codepoint's ESLint config file for modern web development projects",
   "name": "@codepointtku/eslint-config-jsx-eslint",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "eslint",
     "eslintconfig"


### PR DESCRIPTION
Moved naming from City of Turku, to Codepoint Turku since this was technically made for Codepoint Turku.
The original reason why it was named after City of Turku was because it was built with City of Turku's web development standards in mind.